### PR TITLE
アクタでURLのコントローラをネストするように設定を変更

### DIFF
--- a/telledge/Controllers/Student/RoomsController.cs
+++ b/telledge/Controllers/Student/RoomsController.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Web;
+using System.Web.Mvc;
+
+namespace telledge.Controllers.Student
+{
+    public class RoomsController : Controller
+    {
+        //
+        // GET: /Rooms/
+
+        public ActionResult Index()
+        {
+            return View();
+        }
+
+        //
+        // GET: /Rooms/Details/5
+
+        public ActionResult Details(int id)
+        {
+            return View();
+        }
+
+        //
+        // GET: /Rooms/Create
+
+        public ActionResult Create()
+        {
+            return View();
+        } 
+
+        //
+        // POST: /Rooms/Create
+
+        [HttpPost]
+        public ActionResult Create(FormCollection collection)
+        {
+            try
+            {
+                // TODO: Add insert logic here
+
+                return RedirectToAction("Index");
+            }
+            catch
+            {
+                return View();
+            }
+        }
+        
+        //
+        // GET: /Rooms/Edit/5
+ 
+        public ActionResult Edit(int id)
+        {
+            return View();
+        }
+
+        //
+        // POST: /Rooms/Edit/5
+
+        [HttpPost]
+        public ActionResult Edit(int id, FormCollection collection)
+        {
+            try
+            {
+                // TODO: Add update logic here
+ 
+                return RedirectToAction("Index");
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        //
+        // GET: /Rooms/Delete/5
+ 
+        public ActionResult Delete(int id)
+        {
+            return View();
+        }
+
+        //
+        // POST: /Rooms/Delete/5
+
+        [HttpPost]
+        public ActionResult Delete(int id, FormCollection collection)
+        {
+            try
+            {
+                // TODO: Add delete logic here
+ 
+                return RedirectToAction("Index");
+            }
+            catch
+            {
+                return View();
+            }
+        }
+    }
+}

--- a/telledge/Global.asax.cs
+++ b/telledge/Global.asax.cs
@@ -9,6 +9,7 @@ namespace telledge
 {
     // メモ: IIS6 または IIS7 のクラシック モードの詳細については、
     // http://go.microsoft.com/?LinkId=9394801 を参照してください
+    // https://stackoverflow.com/questions/19777880/controller-with-same-name-as-an-area-asp-net-mvc4 を参考
 
     public class MvcApplication : System.Web.HttpApplication
     {

--- a/telledge/Global.asax.cs
+++ b/telledge/Global.asax.cs
@@ -21,7 +21,12 @@ namespace telledge
                 "{controller}/{action}/{id}", // パラメーター付きの URL
                 new { controller = "Home", action = "Index", id = UrlParameter.Optional } // パラメーターの既定値
             );
-
+            routes.MapRoute(
+                "Student",
+                "student/{controller}/{action}/{id}",
+                new { id = UrlParameter.Optional },
+                namespaces: new[] { "telledge.Controllers.Student" }
+            );
         }
 
         protected void Application_Start()

--- a/telledge/Global.asax.cs
+++ b/telledge/Global.asax.cs
@@ -16,18 +16,18 @@ namespace telledge
         public static void RegisterRoutes(RouteCollection routes)
         {
             routes.IgnoreRoute("{resource}.axd/{*pathInfo}");
-
+            routes.MapRoute(
+                "Student",
+                "student/{controller}/{action}/{id}",
+                new { id = UrlParameter.Optional },
+                new[] { "telledge.Controllers.Student" }
+            );
             routes.MapRoute(
                 "Default", // ルート名
                 "{controller}/{action}/{id}", // パラメーター付きの URL
                 new { controller = "Home", action = "Index", id = UrlParameter.Optional } // パラメーターの既定値
             );
-            routes.MapRoute(
-                "Student",
-                "student/{controller}/{action}/{id}",
-                new { id = UrlParameter.Optional },
-                namespaces: new[] { "telledge.Controllers.Student" }
-            );
+
         }
 
         protected void Application_Start()

--- a/telledge/Views/Rooms/index.aspx
+++ b/telledge/Views/Rooms/index.aspx
@@ -1,0 +1,11 @@
+﻿<%@ Page Title="" Language="C#" MasterPageFile="~/Views/Shared/Site.Master" Inherits="System.Web.Mvc.ViewPage<dynamic>" %>
+
+<asp:Content ID="Content1" ContentPlaceHolderID="TitleContent" runat="server">
+	index
+</asp:Content>
+
+<asp:Content ID="Content2" ContentPlaceHolderID="MainContent" runat="server">
+
+    <h2>index</h2>
+
+</asp:Content>

--- a/telledge/telledge.csproj
+++ b/telledge/telledge.csproj
@@ -80,6 +80,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="Global.asax" />
+    <Content Include="Views\Rooms\index.aspx" />
     <Content Include="Web.config">
       <SubType>Designer</SubType>
     </Content>

--- a/telledge/telledge.csproj
+++ b/telledge/telledge.csproj
@@ -68,6 +68,7 @@
   <ItemGroup>
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\Student\RoomsController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
     </Compile>
@@ -114,6 +115,8 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
+    <Folder Include="Controllers\Admin\" />
+    <Folder Include="Controllers\Teacher\" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v10.0\WebApplications\Microsoft.WebApplication.targets" />


### PR DESCRIPTION
重複したコントローラ名のコントローラでもnamespaceによって別のコントローラとして解釈が可能になった。
今回の設定では仮にStudentのみに対して設定。