### PR TITLE
生徒通話画面へ対応拒否された時の処理を実装

### DIFF
--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -47,6 +47,9 @@ $(function () {
 		console.log(arg);
 		if (arg.student_id == studentId) {
 			//リジェクトされたのが自分ならば
+			$("reject-modal").modal('show',{
+				backdrop: "static"
+			});
 			console.log("you are rejected...");
 		}
 		else {

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -47,9 +47,10 @@ $(function () {
 		console.log(arg);
 		if (arg.student_id == studentId) {
 			//リジェクトされたのが自分ならば
-			$("#reject-modal").modal('show',{
+			$("#reject-modal").modal({
 				backdrop: "static"
 			});
+			$("#reject-modal").modal('show');
 			console.log("you are rejected...");
 		}
 		else {

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -47,7 +47,7 @@ $(function () {
 		console.log(arg);
 		if (arg.student_id == studentId) {
 			//リジェクトされたのが自分ならば
-			$("reject-modal").modal('show',{
+			$("#reject-modal").modal('show',{
 				backdrop: "static"
 			});
 			console.log("you are rejected...");

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -47,11 +47,13 @@ $(function () {
 		console.log(arg);
 		if (arg.student_id == studentId) {
 			//リジェクトされたのが自分ならば
+
+			//モーダルウィンドウの外側をクリックすることでモーダルウィンドウを閉じれないようにする
 			$("#reject-modal").modal({
 				backdrop: "static"
 			});
+			// モーダルウィンドウを開く
 			$("#reject-modal").modal('show');
-			console.log("you are rejected...");
 		}
 		else {
 			//リジェクトされたのが他人ならば

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -44,7 +44,6 @@ $(function () {
 
 	// RoomHubクラスのrejectRoomメソッドから呼び出す処理
 	echo.on("reject", (arg) => {
-		console.log(arg);
 		if (arg.student_id == studentId) {
 			//リジェクトされたのが自分ならば
 

--- a/telledge/Views/Students/Rooms/call.cshtml
+++ b/telledge/Views/Students/Rooms/call.cshtml
@@ -111,10 +111,11 @@
 		</div>
 	</main>
 
+	<!-- 評価のモーダルウィンドウ -->
 	<div class="modal fade" id="review-modal" tabindex="-1">
 		<div class="modal-dialog">
 			<div class="modal-content">
-				<form action="/student/rooms/end" method="post" >
+				<form action="/student/rooms/end" method="post">
 					<input name="id" type="hidden" value="@(Model.id)" />
 					<div class="modal-header">
 						<button type="button" class="close" data-dismiss="modal"><span>×</span></button>
@@ -129,6 +130,28 @@
 						<input type="submit" class="btn btn-primary" />
 					</div>
 				</form>
+			</div>
+		</div>
+	</div>
+
+	<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#reject-modal">
+		リジェクトモーダル
+	</button>
+	<!-- リジェクトのモーダルウィンドウ -->
+	<div class="modal fade" id="reject-modal" tabindex="-1">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<button type="button" class="close" data-dismiss="modal"><span>×</span></button>
+					<h4 class="modal-title">タイトル</h4>
+				</div>
+				<div class="modal-body">
+					本文
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
+					<button type="button" class="btn btn-primary">ボタン</button>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/telledge/Views/Students/Rooms/call.cshtml
+++ b/telledge/Views/Students/Rooms/call.cshtml
@@ -134,23 +134,21 @@
 		</div>
 	</div>
 
-	<button type="button" class="btn btn-primary btn-lg" data-toggle="modal" data-target="#reject-modal">
-		リジェクトモーダル
-	</button>
 	<!-- リジェクトのモーダルウィンドウ -->
 	<div class="modal fade" id="reject-modal" tabindex="-1">
 		<div class="modal-dialog">
 			<div class="modal-content">
 				<div class="modal-header">
 					<button type="button" class="close" data-dismiss="modal"><span>×</span></button>
-					<h4 class="modal-title">タイトル</h4>
+					<h4 class="modal-title">お知らせ</h4>
 				</div>
 				<div class="modal-body">
-					本文
+					この度はルームへのご参加誠にありがとうございます。<br />
+					大変申し訳ございませんが、担当講師の力不足によりお客様へ満足のできるレッスンを提供することが難しいと判断したためレッスンの提供を中止しました。<br />
+					お手数をおかけしますが別の講師のルームに再参加していただくよう宜しくお願い申し上げます。
 				</div>
 				<div class="modal-footer">
-					<button type="button" class="btn btn-default" data-dismiss="modal">閉じる</button>
-					<button type="button" class="btn btn-primary">ボタン</button>
+					<button type="button" class="btn btn-primary" onclick="location.href='/student/rooms/index'">ルーム一覧へ戻る</button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
生徒は通話画面にて対応拒否（以下、リジェクト）された場合、WebSocketのブロードキャスト信号を検知し、モーダルウィンドウを表示する処理を実装。
動作確認済み。

モーダルウィンドウ表示中にページをリロードをするとデータが消えている関係上、例外がスローされるが一旦無視。
根本的な解決策募集中。