### PR TITLE
生徒の通話画面の待機人数などの情報を更新する処理を実装

### DIFF
--- a/telledge/Controllers/Students/RoomsController.cs
+++ b/telledge/Controllers/Students/RoomsController.cs
@@ -134,7 +134,7 @@ namespace telledge.Controllers.Students
 				student_name = section.getStudent().name,
 				request = section.request
 			});
-			GlobalHost.ConnectionManager.GetHubContext<RoomHub>().Clients.Group("student_room_" + id).updateWaitInfo(room.getSections());
+			GlobalHost.ConnectionManager.GetHubContext<RoomHub>().Clients.Group("student_room_" + id).updateWaitInfo(room, room.getSections());
 			return RedirectToAction("call", "rooms", new { Id = Convert.ToInt32(id) });
 		}
 

--- a/telledge/Controllers/Students/RoomsController.cs
+++ b/telledge/Controllers/Students/RoomsController.cs
@@ -134,7 +134,7 @@ namespace telledge.Controllers.Students
 				student_name = section.getStudent().name,
 				request = section.request
 			});
-			GlobalHost.ConnectionManager.GetHubContext<RoomHub>().Clients.Group("student_room_" + id).updateWaitInfo(room.getWaitTime(), room.getWaitCount());
+			GlobalHost.ConnectionManager.GetHubContext<RoomHub>().Clients.Group("student_room_" + id).updateWaitInfo(room.getSections());
 			return RedirectToAction("call", "rooms", new { Id = Convert.ToInt32(id) });
 		}
 

--- a/telledge/Hubs/RoomHub.cs
+++ b/telledge/Hubs/RoomHub.cs
@@ -65,7 +65,7 @@ namespace telledge.Hubs
 				Student room_section_student = room_section == null ? null : room_section.getStudent();
 				Clients.Group("teacher_room_" + roomId).endCall(room_section, room_section_student);
 				Clients.Group("student_room_" + roomId).endCall(roomId, studentId);
-				//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
+				Clients.Group("student_room_" + roomId).updateWaitInfo(room, room.getSections());    //生徒の待ち情報を更新する
 			}
 		}
 		// 生徒がルームから退出した時の処理
@@ -77,7 +77,7 @@ namespace telledge.Hubs
 			section.studentId = studentId;
 			section.delete();
 			Clients.Group("teacher_room_" + roomId).removeStudent(studentId);   //講師のリストから削除する
-			//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());	//生徒の待ち情報を更新する
+			Clients.Group("student_room_" + roomId).updateWaitInfo(room, room.getSections());	//生徒の待ち情報を更新する
 		}
 
 		//講師が生徒を対応拒否した場合の処理
@@ -93,7 +93,7 @@ namespace telledge.Hubs
 				student_id = studentId
 				//待ち人数と待ち時間を更新して同時に返す処理をここに実装予定
 			});
-			//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
+			Clients.Group("student_room_" + roomId).updateWaitInfo(room, room.getSections());    //生徒の待ち情報を更新する
 		}
 		public void Hello()
 		{

--- a/telledge/Hubs/RoomHub.cs
+++ b/telledge/Hubs/RoomHub.cs
@@ -49,7 +49,7 @@ namespace telledge.Hubs
 				student_name = section.getStudent().name,
 				request = section.request
 			});
-			Clients.Group("student_room_" + roomId).updateWaitInfo(room.getSections());
+			Clients.Group("student_room_" + roomId).updateWaitInfo(room, room.getSections());
 		}
 		//通話を終了する信号を受け取ったときに実行する処理（呼び出し元は問わない）
 		public void endCall(int roomId, int studentId)

--- a/telledge/Hubs/RoomHub.cs
+++ b/telledge/Hubs/RoomHub.cs
@@ -49,7 +49,7 @@ namespace telledge.Hubs
 				student_name = section.getStudent().name,
 				request = section.request
 			});
-			Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());
+			Clients.Group("student_room_" + roomId).updateWaitInfo(room.getSections());
 		}
 		//通話を終了する信号を受け取ったときに実行する処理（呼び出し元は問わない）
 		public void endCall(int roomId, int studentId)
@@ -65,7 +65,7 @@ namespace telledge.Hubs
 				Student room_section_student = room_section == null ? null : room_section.getStudent();
 				Clients.Group("teacher_room_" + roomId).endCall(room_section, room_section_student);
 				Clients.Group("student_room_" + roomId).endCall(roomId, studentId);
-				Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
+				//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
 			}
 		}
 		// 生徒がルームから退出した時の処理
@@ -77,7 +77,7 @@ namespace telledge.Hubs
 			section.studentId = studentId;
 			section.delete();
 			Clients.Group("teacher_room_" + roomId).removeStudent(studentId);   //講師のリストから削除する
-			Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());	//生徒の待ち情報を更新する
+			//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());	//生徒の待ち情報を更新する
 		}
 
 		//講師が生徒を対応拒否した場合の処理
@@ -93,7 +93,7 @@ namespace telledge.Hubs
 				student_id = studentId
 				//待ち人数と待ち時間を更新して同時に返す処理をここに実装予定
 			});
-			Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
+			//Clients.Group("student_room_" + roomId).updateWaitInfo(room.getWaitTime(), room.getWaitCount());    //生徒の待ち情報を更新する
 		}
 		public void Hello()
 		{

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -94,23 +94,18 @@ $(function () {
 
 	//情報を更新するメソッド
 	//updateWaitInfo(sectionの配列オブジェクト)
-	echo.on("updateWaitInfo", (sections) => {
-		sections.sort((a, b) => {
-			if (a.order < b.order) return -1;
-			if (a.order > b.order) return 1;
-			return 0;
-		});
-
+	echo.on("updateWaitInfo", (room, sections) => {
 		// 自分のorderを求める
 		const order = sections.find(section => section.studentId > studentId).order;
 
-
-
-		console.log(sections);
-
-		sections.some((section) => {
-
+		// 自分より前に並んでいる情報を抽出する
+		const selected_sections = sections.filter((section) => {
+			return section.order < order;
 		});
+
+		const waitTime = selected_sections.length * (room.worstTime + room.extensionTime) / 2;
+		const waitCount = selected_sections.length;
+
 		$('#waitTime').text(waitTime);
 		$('#waitCount').text(waitCount);
 	});

--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -93,8 +93,24 @@ $(function () {
 	});
 
 	//情報を更新するメソッド
-	//updateWaitInfo(更新後の予想待ち時間、更新後の待機人数)
-	echo.on("updateWaitInfo", (waitTime, waitCount) => {
+	//updateWaitInfo(sectionの配列オブジェクト)
+	echo.on("updateWaitInfo", (sections) => {
+		sections.sort((a, b) => {
+			if (a.order < b.order) return -1;
+			if (a.order > b.order) return 1;
+			return 0;
+		});
+
+		// 自分のorderを求める
+		const order = sections.find(section => section.studentId > studentId).order;
+
+
+
+		console.log(sections);
+
+		sections.some((section) => {
+
+		});
 		$('#waitTime').text(waitTime);
 		$('#waitCount').text(waitCount);
 	});


### PR DESCRIPTION
サーバーが全生徒へsectionの情報を渡し、それぞれの生徒のクライアントで解釈し、最適な待ち時間を計算するようにする処理を実装。
生徒２人にてテスト済み。