### PR TITLE
生徒と講師のアカウント作成後の遷移先修正

### DIFF
--- a/telledge/Controllers/Students/RegistrationsController.cs
+++ b/telledge/Controllers/Students/RegistrationsController.cs
@@ -38,7 +38,7 @@ namespace telledge.Controllers.Students
 					student.name = DBNull.Value.ToString();
 					student.profileImage = DBNull.Value.ToString();
 					student.create();
-					return View("/Views/Students/Registrations/top.cshtml");
+					return View("/Views/Homes/top.cshtml");
 				}
 			}
 			return View("/Views/Students/Registrations/create.cshtml");

--- a/telledge/Controllers/Students/RegistrationsController.cs
+++ b/telledge/Controllers/Students/RegistrationsController.cs
@@ -38,7 +38,8 @@ namespace telledge.Controllers.Students
 					student.name = DBNull.Value.ToString();
 					student.profileImage = DBNull.Value.ToString();
 					student.create();
-					return View("/Views/Homes/top.cshtml");
+					Student.login(mailaddress, password);
+					return View("/Views/Students/Homes/mypage.cshtml",Student.currentUser());
 				}
 			}
 			return View("/Views/Students/Registrations/create.cshtml");

--- a/telledge/Controllers/Teachers/RegistrationsController.cs
+++ b/telledge/Controllers/Teachers/RegistrationsController.cs
@@ -41,17 +41,18 @@ namespace telledge.Controllers.Teachers
 					teacher.name = name;
 					teacher.mailaddress = mailaddress;
 					teacher.setPassword(password);//パスワードダイジェスト化
-				if (imagePath != null)
-				{
-					imagePath.SaveAs(Server.MapPath(@"/uproadFiles/") + Path.GetFileName(imagePath.FileName));
-					teacher.profileImage = Path.GetFileName(imagePath.FileName);
-				}	
+					if (imagePath != null)
+					{
+						imagePath.SaveAs(Server.MapPath(@"/uproadFiles/") + Path.GetFileName(imagePath.FileName));
+						teacher.profileImage = Path.GetFileName(imagePath.FileName);
+					}	
 					teacher.language = DBNull.Value.ToString();
 					teacher.intoroduction = DBNull.Value.ToString();
 					teacher.address = DBNull.Value.ToString();
 					teacher.nationality = DBNull.Value.ToString();
 					teacher.create();
-					return View("/Views/Homes/top.cshtml");
+					Teacher.login(mailaddress,password);
+					return View("/Views/Teachers/Homes/mypage.cshtml",Teacher.currentUser());
 				}
 			}
 			return View("/Views/Teachers/Registrations/create.cshtml");

--- a/telledge/Controllers/Teachers/RegistrationsController.cs
+++ b/telledge/Controllers/Teachers/RegistrationsController.cs
@@ -51,7 +51,7 @@ namespace telledge.Controllers.Teachers
 					teacher.address = DBNull.Value.ToString();
 					teacher.nationality = DBNull.Value.ToString();
 					teacher.create();
-					return View("/Views/Teachers/Registrations/top.cshtml");
+					return View("/Views/Homes/top.cshtml");
 				}
 			}
 			return View("/Views/Teachers/Registrations/create.cshtml");

--- a/telledge/Views/Students/Homes/mypage.cshtml
+++ b/telledge/Views/Students/Homes/mypage.cshtml
@@ -39,22 +39,29 @@
 			<h3><span>受講履歴</span></h3>
 			<ul>
 				<li>
-					<table>
-						<tr>
-							<td><span class="list-width">講師名</span></td>
-							<td><span class="list-width">ルーム名</span></td>
-							<td><span class="list-width">特徴タグ</span></td>
-						</tr>
-
-						@foreach (var item in Model.GetSections())
+					@if (Model.GetSections() != null)
+					{
+						foreach (var item in Model.GetSections())
 						{
-							<tr>
-								<td><span class="list-width">@item.getRoom().getTeacher().name</span>
-								<td><span class="list-width">@item.getRoom().roomName</span>
-								<td><span class="list-width">@item.getRoom().tag</span>
-							</tr>
+							<table>
+								<tr>
+									<td><span class="list-width">講師名</span></td>
+									<td><span class="list-width">ルーム名</span></td>
+									<td><span class="list-width">特徴タグ</span></td>
+								</tr>
+								<tr>
+									<td><span class="list-width">@item.getRoom().getTeacher().name</span>
+									<td><span class="list-width">@item.getRoom().roomName</span>
+									<td><span class="list-width">@item.getRoom().tag</span>
+								</tr>
+							</table>
 						}
-					</table>
+					}
+					else
+					{
+						<span class="list-width" style="text-align:center">受講履歴無し</span>
+					}
+
 				</li>
 			</ul>
 		</li>

--- a/telledge/Views/Students/Homes/mypage.cshtml
+++ b/telledge/Views/Students/Homes/mypage.cshtml
@@ -19,7 +19,6 @@
 			<ul>
 				<li><span class="list-width">メールアドレス</span>@Model.mailaddress</li>
 				<li><span class="list-width">ユーザー名</span>@Model.name</li>
-				<li><span class="list-width">プロフィール画像</span>@Model.profileImage</li>
 				<li><span class="list-width">SkypeID</span>@Model.skypeId</li>
 				<li>
 					<button class="btn btn-primary center" type="button" onclick="location.href='/Student/homes/edit'">変更</button>


### PR DESCRIPTION
・アカウント作成後の遷移先修正
・アカウント作成成功時にマイページへ遷移する。
・生徒の受講履歴がない場合の処理を追加