### PR TITLE
講師のアカウント作成画面のデザインの修正

### DIFF
--- a/telledge/StyleSheets/signin.css
+++ b/telledge/StyleSheets/signin.css
@@ -11,6 +11,3 @@
 .small{
 	font-size:xx-small;
 }
-#margin-left{
-	margin-left:30%;
-}

--- a/telledge/StyleSheets/signin.css
+++ b/telledge/StyleSheets/signin.css
@@ -11,3 +11,6 @@
 .small{
 	font-size:xx-small;
 }
+#margin-left{
+	margin-left:30%;
+}

--- a/telledge/Views/Teachers/Registrations/create.cshtml
+++ b/telledge/Views/Teachers/Registrations/create.cshtml
@@ -40,7 +40,7 @@
 			<span>証明写真</span>
 		</div>
 		<div>
-			<span><input asp-for="FileUpload.FormatFile" type="file" name="imagePath" id="imagePath" /></span>
+			<span><input asp-for="FileUpload.FormatFile" type="file" name="imagePath" id="imagePath" style="margin-left:30%"/></span>
 		</div>
 		<div class="small">
 			<span>


### PR DESCRIPTION
・ファイル選択が左寄りになってたため、中央に配置