### PR TITLE
ルーム作成画面のUX向上

### DIFF
--- a/telledge/Views/Teachers/Rooms/Create.cshtml
+++ b/telledge/Views/Teachers/Rooms/Create.cshtml
@@ -47,7 +47,7 @@
 			</tr>
 			<tr>
 				<td>通話終了予定時刻</td>
-				<td><input type="text" name="endScheduleTime" value=""></td>
+				<td><input type="datetime" name="endScheduleTime" value=""></td>
 			</tr>
 			<tr>
 				<td id="margin-bottom"><input class="btn btn-default" type="submit" value="ルーム作成"></td>

--- a/telledge/Views/Teachers/Rooms/Create.cshtml
+++ b/telledge/Views/Teachers/Rooms/Create.cshtml
@@ -34,20 +34,20 @@
 				</td>
 			</tr>
 			<tr>
-				<td>最低保障時間</td>
-				<td><input type="text" name="worstTime" value=""></td>
+				<td>最低保障時間(分)</td>
+				<td><input type="number" name="worstTime" value=""></td>
 			</tr>
 			<tr>
-				<td>最大延長時間</td>
-				<td><input type="text" name="extensionTime" value=""></td>
+				<td>最大延長時間(分)</td>
+				<td><input type="number" name="extensionTime" value=""></td>
 			</tr>
 			<tr>
 				<td>ポイント</td>
-				<td><input type="text" name="point" value=""></td>
+				<td><input type="number" name="point" value=""></td>
 			</tr>
 			<tr>
 				<td>通話終了予定時刻</td>
-				<td><input type="datetime" name="endScheduleTime" value=""></td>
+				<td><input type="datetime-local" name="endScheduleTime" value="" step="600" ></td>
 			</tr>
 			<tr>
 				<td id="margin-bottom"><input class="btn btn-default" type="submit" value="ルーム作成"></td>


### PR DESCRIPTION
・数字の入力項目をnumberへ変更
・終了予定時間をdatetime-localへ変更し、カレンダー入力へ対応

ルーム作成のテスト(データベースへの登録)確認済み。
![キャプチャ](https://user-images.githubusercontent.com/42799529/73618366-a3fd8500-466a-11ea-8414-95ea7ca8f5d2.PNG)
