### PR TITLE
ルーム終了処理の実装

### DIFF
--- a/telledge/Controllers/Teachers/RoomsController.cs
+++ b/telledge/Controllers/Teachers/RoomsController.cs
@@ -59,20 +59,22 @@ namespace telledge.Controllers.Teachers
 				return View("/Views/Teachers/Sessions/create.cshtml");
 			}
 		}
-		public ActionResult delete(int roomId)
+		public ActionResult delete(int id)
 		{
-			Room room = new Room();
-			room.id = roomId;
-			Section[] section = room.getSections();
-			for (int i = 0; i < section.Length; i++)
+			Room room = Room.find(id);
+			room.id = id;
+			Section[] sections = room.getSections();
+			if (sections != null)
 			{
-				if (section[i].talkTime == null)
+				foreach (Section section in sections)
 				{
-					section[i].delete();
+					if (section.talkTime == null)
+						section.delete();
 				}
 			}
 			room.close();
-			return View("/Views/Teachers/Homes/mypage.cshtml");
+			room.update();
+			return View("/Views/Teachers/Homes/mypage.cshtml", Teacher.currentUser());
 		}
 		[HttpGet]
 		public ActionResult show(int roomid)

--- a/telledge/Scripts/Telledge/teacherRoomCall.js
+++ b/telledge/Scripts/Telledge/teacherRoomCall.js
@@ -99,7 +99,7 @@ $(function () {
 
 	$('#room-end').click(() => {
 		echo.invoke("endRoom", roomId);
-		location.href ='/teacher/rooms/index';
+		location.href = '/teacher/rooms/delete/' + roomId;
 	});
 
 	//通話終了ボタンの入力を検知したときの処理


### PR DESCRIPTION
実装されていなかったルーム終了処理を実装。
・ルーム終了時、通話の完了していない生徒全員のデータをSectionテーブルから削除。
・Roomテーブルにある該当のデータの終了時間を記録。
上記内容テスト済み。