### PR TITLE
レビューを入力せずに投稿する問題を修正

### DIFF
--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -78,6 +78,10 @@ $(function () {
 		}
 	});
 
+	$("#raty img").click(() => {
+		$('#submit-review-button').removeAttr('disabled');
+	});
+
 	echo.on("endRoom", () => {
 		$("#end-room-modal").modal({
 			backdrop: "static"

--- a/telledge/Views/Students/Rooms/call.cshtml
+++ b/telledge/Views/Students/Rooms/call.cshtml
@@ -1,4 +1,4 @@
-﻿@model telledge.Models.Room
+@model telledge.Models.Room
 
 
 @{
@@ -152,7 +152,7 @@
 						</div>
 					</div>
 					<div class="modal-footer">
-						<input type="submit" class="btn btn-primary" />
+						<input id="submit-review-button" type="submit" class="btn btn-primary" value="送信" disabled="disabled" />
 					</div>
 				</form>
 			</div>


### PR DESCRIPTION
レビューの星を押す前はボタンを無効にしておき、ボタンを押すと有効にするコードを追加。
#295 の問題へ対応。