### PR TITLE
通話開始時間が記録されない問題へ対処

### DIFF
--- a/telledge/Controllers/Students/RoomsController.cs
+++ b/telledge/Controllers/Students/RoomsController.cs
@@ -134,6 +134,7 @@ namespace telledge.Controllers.Students
 			if (Student.currentUser() == null) return RedirectToAction("create", "sessions");
 			Room room = Room.find(id);
 			Section section = new Section();
+			section.beginTime = DateTime.Now;
 			section.roomId = id;
 			section.studentId = Student.currentUser().id;
 			section.request = request;


### PR DESCRIPTION
通話開始時にbeginTimeへの代入が行われていなかったため、修正
#298 へ対応