### PR TITLE
生徒の延長時間終了時の処理を実装

### DIFF
--- a/telledge/Scripts/Telledge/studentRoomsCall.js
+++ b/telledge/Scripts/Telledge/studentRoomsCall.js
@@ -27,6 +27,12 @@ con.setCallback(Status.Extend, () => {
 	$('#timer-status').css('color', 'red');
 	$('#timer-status').text("延長時間");
 });
+con.setCallback(Status.AllDone, () => {
+	$("#expire-end-room-modal").modal({
+		backdrop: "static"
+	});
+	$("#expire-end-room-modal").modal('show');
+});
 
 
 

--- a/telledge/Scripts/Timer.js
+++ b/telledge/Scripts/Timer.js
@@ -35,6 +35,7 @@ class Timer{
 		}
 		else if (this.status == Status.AllDone) {
 			//すべての処理が完了したときの処理
+			clearInterval(this.interval);
 		}
 		else {
 			this.status = Status.Undefined;

--- a/telledge/Views/Students/Rooms/call.cshtml
+++ b/telledge/Views/Students/Rooms/call.cshtml
@@ -195,5 +195,24 @@
 			</div>
 		</div>
 	</div>
+
+	<!-- 延長時間終了のモーダルウィンドウ -->
+	<div class="modal fade" id="expire-end-room-modal" tabindex="-1">
+		<div class="modal-dialog">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h4 class="modal-title">お知らせ</h4>
+				</div>
+				<div class="modal-body">
+					この度はルームへのご参加誠にありがとうございます。<br />
+					延長時間が終了しましたので通話を終了しました。<br />
+					この度はTelledgeのご利用、ありがとうございました。
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-primary" onclick="location.href='/student/rooms/index'">ルーム一覧へ戻る</button>
+				</div>
+			</div>
+		</div>
+	</div>
 </body>
 </html>


### PR DESCRIPTION
生徒の通話画面にて、延長時間が終了した際に終了を示すモーダルウィンドウを表示し、ルーム一覧画面へ移動させるように変更。
#293 への対応